### PR TITLE
ncurses: include_curses.head.ed: fix a macro for bool

### DIFF
--- a/devel/ncurses/files/include_curses.head.ed
+++ b/devel/ncurses/files/include_curses.head.ed
@@ -1,5 +1,5 @@
 /typedef.*NCURSES_BOOL;/c
-#if defined(__LP64__) || !defined(__POWERPC__)
+#if defined(__LP64__) || !defined(__ppc__)
 typedef unsigned char NCURSES_BOOL;
 #else
 typedef unsigned int NCURSES_BOOL;


### PR DESCRIPTION
The only arch where we have 4-byte bool is `ppc`; `ppc64` has 1-byte bool.
(If `__LP64__` is _always_ defined on `ppc64`, the change is merely cosmetic.)