### PR TITLE
nss: unbreak build on riscv64

### DIFF
--- a/net/nss/Portfile
+++ b/net/nss/Portfile
@@ -141,11 +141,12 @@ array set cpu_arch_map [list \
     arm64   aarch64 \
     ppc     ppc \
     ppc64   ppc64 \
+    riscv64 riscv64 \
     i386    x86 \
     x86_64  x86_64]
 
 if {!${universal_possible} || ![variant_isset universal]} {
-    if {${configure.build_arch} in [list arm64 ppc64 x86_64]} {
+    if {${configure.build_arch} in [list arm64 ppc64 riscv64 x86_64]} {
         build.args-append USE_64=1
     }
     if {[info exists cpu_arch_map(${configure.build_arch})]} {


### PR DESCRIPTION
Closes: https://github.com/RJVB/lnxports/issues/19

(Turned out, it is not an upstream bug.)