### PR TITLE
xorg-libxcb: fix deps: xorg-libXau needed on Linux as well

### DIFF
--- a/x11/xorg-libxcb/Portfile
+++ b/x11/xorg-libxcb/Portfile
@@ -29,15 +29,11 @@ use_parallel_build yes
 
 depends_build   port:pkgconfig
 
-platform darwin {
-    depends_lib port:xorg-libXdmcp \
+depends_lib     port:xorg-libXau \
+                port:xorg-libXdmcp \
                 port:xorg-libpthread-stubs
-}
-depends_lib-append \
-                port:xorg-libXau \
                 port:xorg-xcb-proto
 
-configure.save_configure_cmd "install log"
 configure.args  --disable-devel-docs \
                 --disable-silent-rules \
                 --enable-ge --enable-xevie --enable-xprint
@@ -121,6 +117,8 @@ if {[info exists python_version]} {
     ui_error "${subport} needs a Python variant to be set"
     return -code error "Missing variant"
 }
+
+configure.save_configure_cmd "install log"
 
 livecheck.type  regex
 livecheck.url   https://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-libxcb/Portfile
+++ b/x11/xorg-libxcb/Portfile
@@ -30,11 +30,11 @@ use_parallel_build yes
 depends_build   port:pkgconfig
 
 platform darwin {
-    depends_lib port:xorg-libXau \
-                port:xorg-libXdmcp \
+    depends_lib port:xorg-libXdmcp \
                 port:xorg-libpthread-stubs
 }
 depends_lib-append \
+                port:xorg-libXau \
                 port:xorg-xcb-proto
 
 configure.save_configure_cmd "install log"

--- a/x11/xorg-libxcb/Portfile
+++ b/x11/xorg-libxcb/Portfile
@@ -31,7 +31,7 @@ depends_build   port:pkgconfig
 
 depends_lib     port:xorg-libXau \
                 port:xorg-libXdmcp \
-                port:xorg-libpthread-stubs
+                port:xorg-libpthread-stubs \
                 port:xorg-xcb-proto
 
 configure.args  --disable-devel-docs \


### PR DESCRIPTION
Fails to configure if libXau is missing:
```
configure: WARNING: doxygen not found - documentation targets will be skipped
configure: WARNING: dot not found - doxygen targets will be skipped
checking for check >= 0.9.6... no
checking for xcb-proto >= 1.17.0... yes
checking for xau >= 0.99.2... no
configure: error: Package requirements (xau >= 0.99.2) were not met:

No package 'xau' found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables NEEDED_CFLAGS
and NEEDED_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
Command failed:  cd "/opt/local/var/macports/build/_home_svacchanda_lnxports_x11_xorg-libxcb/xorg-libxcb/work/libxcb-1.17.0" && bash -o pipefail -c './configure  --prefix=/opt/local --disable-devel-docs --disable-silent-rules --enable-ge --enable-xevie --enable-xprint |& tee /opt/local/var/macports/build/_home_svacchanda_lnxports_x11_xorg-libxcb/xorg-libxcb/work/.macports.xorg-libxcb.configure.log'
```