### PR TITLE
neofetch: support ports info on non-Apple systems

### DIFF
--- a/sysutils/neofetch/Portfile
+++ b/sysutils/neofetch/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        dylanaraps neofetch 7.1.0
+revision            1
+platforms           any
+supported_archs     noarch
+license             MIT
+maintainers         {@rangeles gmail.com:ronangeles} openmaintainer
+categories          sysutils
+
+description         A CLI system information tool
+long_description    Neofetch is a CLI system information tool written in \
+                    BASH. Neofetch displays information about your system \
+                    next to an image, your OS logo, or any ASCII file of \
+                    your choice.
+
+checksums           rmd160  c9db23b6959aa7d0b8b6de68c05994f80d1e846a \
+                    sha256  c99d704d2f321d24a4655ce3fc052fd79539493dc75c025237ad78e93f9749bf \
+                    size    95403
+
+patchfiles-append   0001-Support-MacPorts-on-non-Darwin-systems.patch
+
+use_configure       no
+destroot.post_args  ${destroot.destdir} PREFIX=${prefix}

--- a/sysutils/neofetch/files/0001-Support-MacPorts-on-non-Darwin-systems.patch
+++ b/sysutils/neofetch/files/0001-Support-MacPorts-on-non-Darwin-systems.patch
@@ -1,0 +1,21 @@
+From 6cb9041c463cea4df03fd52f736cadee959d3bef Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sun, 25 Aug 2024 08:33:46 +0800
+Subject: [PATCH] Support MacPorts on non-Darwin systems
+
+---
+ neofetch | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git neofetch neofetch
+index 48b96d21..b00bae27 100755
+--- neofetch
++++ neofetch
+@@ -1504,6 +1504,7 @@
+             has alps       && tot alps showinstalled
+             has butch      && tot butch list
+             has mine       && tot mine -q
++            has port       && pkgs_h=1 tot port installed && ((packages-=1))
+ 
+             # Counting files/dirs.
+             # Variables need to be unquoted here. Only Bedrock Linux is affected.


### PR DESCRIPTION
Maintainer of `neofetch` in MacPorts is not interested to fix or improve it, and upstream is no more.
Add the fixed version here (improvement is Linux-specific).

![361184627-517fcb22-dcea-47b1-9ab4-93e9beacb212](https://github.com/user-attachments/assets/dde0a665-73f5-44a7-8600-245b8c788f5c)
